### PR TITLE
Report git version with library_version

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -51,6 +51,10 @@ NATIVEDIR		= $(CORE_DIR)/native
 EXTDIR			= $(CORE_DIR)/ext
 
 TARGET_NAME := ppsspp
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 CC_AS ?= $(CC)
 FFMPEGINCFLAGS :=
 FFMPEGLIBDIR :=

--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 LOCAL_MODULE    := libavformat
 CORE_DIR    := ..
 ROOTDIR     := $(CORE_DIR)/../

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -273,7 +273,10 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
    info->library_name     = "PPSSPP";
-   info->library_version  = "v1.0.1-git";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version  = "v1.0.1-git" GIT_VERSION;
    info->need_fullpath    = true;
    info->valid_extensions = "elf|iso|cso|prx|pbp";
 }


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.